### PR TITLE
Fix typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
  
 | Link                                    | Description                                                                        | 
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
-|  [Regex Learn](https://regexlearn.com/learn/) | Complete 56 short online exercises and learn how to use regular expressions. |
+|  [Regex Learn](https://regexlearn.com/learn) | Complete 56 short online exercises and learn how to use regular expressions. |
 |  [Regex One](https://regexone.com/) | 25 lessons with interactive exercises |
 
 


### PR DESCRIPTION
The URL was directing to https://regexlearn.com/learn/ --> Page not found
Correct URL : https://regexlearn.com/learn
<img width="897" alt="image" src="https://user-images.githubusercontent.com/75565639/205579491-9e8afe6f-2446-453e-b25a-7f658b06c022.png">
